### PR TITLE
add specific igniteui version to fix compatibility issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@lit-labs/context": "^0.3.1",
         "@lit-labs/virtualizer": "^2.0.2",
-        "igniteui-theming": "^1.4.2",
-        "igniteui-webcomponents": "^4.2.3",
+        "igniteui-theming": "1.4.2",
+        "igniteui-webcomponents": "4.2.3",
         "lit": "^2.7.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   "dependencies": {
     "@lit-labs/context": "^0.3.1",
     "@lit-labs/virtualizer": "^2.0.2",
-    "igniteui-theming": "^1.4.2",
-    "igniteui-webcomponents": "^4.2.3",
+    "igniteui-theming": "1.4.2",
+    "igniteui-webcomponents": "4.2.3",
     "lit": "^2.7.4"
   },
   "devDependencies": {


### PR DESCRIPTION
due to caret `^` in version, it was installing latest minor version of igniteui, which has support for theme variant `light/dark`, which is not working with old implementation. using specific version fixes the issue.