### PR TITLE
build: Bumped target to ES2022 and module to ESNext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2021",
-    "module": "es2020",
+    "target": "es2022",
+    "module": "ESNext",
     "lib": ["es2023", "DOM", "DOM.Iterable"],
     "outDir": "dist",
     "rootDir": "./",


### PR DESCRIPTION
Mainly to reduce the boilerplate around private
properties when transpiling